### PR TITLE
getting rid of "no handlers could be found" warning

### DIFF
--- a/turkic/geolocation.py
+++ b/turkic/geolocation.py
@@ -3,6 +3,7 @@ import urllib2
 import logging
 
 logger = logging.getLogger("turkic.geolocation")
+logging.basicConfig()
 
 try:
     import config


### PR DESCRIPTION
`turkic <anycommand>` was giving me the warning 'No handlers could be found for logger 'turkic.geolocation.' Adding `logging.basicConfig()` in geolocation.py seems to be the solution.
